### PR TITLE
Add MiniRpcLib support for DropItem

### DIFF
--- a/DropItems/DropItems.cs
+++ b/DropItems/DropItems.cs
@@ -9,16 +9,72 @@
 	using UnityEngine.EventSystems;
 	using UnityEngine.SceneManagement;
 	using UnityEngine.Networking;
+	using MiniRpcLib.Action;
+	using MiniRpcLib;
+	using System;
+	using BepInEx.Configuration;
+
 
 	[BepInPlugin("com.kookehs.dropitems", "DropItems", "1.1.2")]
-
+	[BepInDependency(MiniRpcLib.MiniRpcPlugin.Dependency)]
 	public class DropItems : BaseUnityPlugin
 	{
 		internal static List<HUD> CachedHudInstancesList { get; set; }
 
+		IRpcAction<GameObject> SendDropEquipmentRequest { get; set; }
+		IRpcAction<Action<NetworkWriter>> SendDropItemRequest { get; set; }
+
+		ConfigWrapper<bool> ClientsCanDrop;
+		ConfigWrapper<bool> HostCanDropOthers;
+		ConfigWrapper<bool> ClientsCanDropOthers;
+
+		private bool IsAllowedToDrop(NetworkUser user, CharacterMaster master) {
+			if (!user.isServer && !ClientsCanDrop.Value)
+				return false;
+			if (user.master != master) {
+				if (user.isServer && !HostCanDropOthers.Value)
+					return false;
+				else if (!ClientsCanDropOthers.Value)
+					return false;
+			}
+			return true;
+		}
+
 		private void Awake()
 		{
+			ClientsCanDrop = Config.Wrap(section: "", key: "clients_can_drop", description: @"Allows client with the mod installed to drop their own items.", defaultValue: true);
+			HostCanDropOthers = Config.Wrap(section: "", key: "host_can_drop_others", description: @"Allows host drop other players' items.", defaultValue: true);
+			ClientsCanDropOthers = Config.Wrap(section: "", key: "clients_can_drop_others", description: @"Allows clients with the mod installed to drop other players' items.", defaultValue: false);
+
 			SceneManager.sceneUnloaded += OnSceneUnloaded;
+			var miniRpc = MiniRpc.CreateInstance("com.kookehs.dropitems");
+
+			SendDropItemRequest = miniRpc.RegisterAction(Target.Server, (user, x) => {
+				var master = x.ReadGameObject();
+				var itemid = x.ReadItemIndex();
+
+				var inventory = master.GetComponent<Inventory>();
+				var characterMaster = master.GetComponent<CharacterMaster>();
+				if (inventory == null || characterMaster == null)
+					return;
+
+				if (!IsAllowedToDrop(user, characterMaster))
+					return;
+
+				DropItem(inventory, itemid);
+			});
+			SendDropEquipmentRequest = miniRpc.RegisterAction(Target.Server, (NetworkUser user, GameObject master) => {
+				var inventory = master.GetComponent<Inventory>();
+				var characterMaster = master.GetComponent<CharacterMaster>();
+				if (inventory == null || characterMaster == null)
+					return;
+
+				if (!IsAllowedToDrop(user, characterMaster))
+					return;
+
+				DropEquipment(inventory);
+			});
+
 			Debug.Log("Loaded DropItemsMod");
 		}
 
@@ -29,8 +85,6 @@
 
 		private void Update()
 		{
-			if (!NetworkServer.active) return;
-
 			if (CachedHudInstancesList == null)
 			{
 				CachedHudInstancesList = (List<HUD>)typeof(HUD).GetField("instancesList", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
@@ -61,6 +115,7 @@
 							Inventory inventory = (Inventory)typeof(ItemInventoryDisplay).GetField("inventory", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(hud.itemInventoryDisplay);
 							dropItemController.Inventory = inventory;
 							dropItemController.ItemIcon = itemIcon;
+							dropItemController.SendDropItemToServer = SendDropItemRequest;
 						}
 					}
 				}
@@ -77,6 +132,7 @@
 						DropItemController dropItemController = equipmentIcon.gameObject.AddComponent<DropItemController>();
 						dropItemController.Inventory = equipmentIcon.targetInventory;
 						dropItemController.EquipmentIcon = equipmentIcon;
+						dropItemController.SendDropEquipmentToServer = SendDropEquipmentRequest;
 					}
 				}
 			}
@@ -112,6 +168,7 @@
 									Inventory inventory = (Inventory)typeof(ItemInventoryDisplay).GetField("inventory", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(scoreboardStrip.itemInventoryDisplay);
 									dropItemController.Inventory = inventory;
 									dropItemController.ItemIcon = itemIcon;
+									dropItemController.SendDropItemToServer = SendDropItemRequest;
 								}
 							}
 						}
@@ -128,10 +185,35 @@
 								DropItemController dropItemController = equipmentIcon.gameObject.AddComponent<DropItemController>();
 								dropItemController.Inventory = equipmentIcon.targetInventory;
 								dropItemController.EquipmentIcon = equipmentIcon;
+								dropItemController.SendDropEquipmentToServer = SendDropEquipmentRequest;
 							}
 						}
 					}
 				}
+			}
+		}
+
+		public static void DropItem(Inventory inventory, ItemIndex itemIndex) {
+			CharacterBody characterBody = inventory.GetComponent<CharacterMaster>().GetBody();
+			if (characterBody == null || characterBody.healthComponent == null || characterBody.healthComponent.alive == false) return;
+			Transform transform = characterBody.transform;
+
+			if (inventory.GetItemCount(itemIndex) != 0) {
+				inventory.RemoveItem(itemIndex, 1);
+				PickupDropletController.CreatePickupDroplet(new PickupIndex(itemIndex), transform.position, Vector3.up * 20f + transform.forward * 10f);
+			}
+		}
+
+		public static void DropEquipment(Inventory inventory) {
+			CharacterBody characterBody = inventory.GetComponent<CharacterMaster>().GetBody();
+			if (characterBody == null || characterBody.healthComponent == null || characterBody.healthComponent.alive == false) return;
+			Transform transform = characterBody.transform;
+
+			EquipmentIndex equipmentIndex = inventory.GetEquipmentIndex();
+			inventory.SetEquipmentIndex(EquipmentIndex.None);
+
+			if (equipmentIndex != EquipmentIndex.None) {
+				PickupDropletController.CreatePickupDroplet(new PickupIndex(equipmentIndex), transform.position, Vector3.up * 20f + transform.forward * 10f);
 			}
 		}
 	}
@@ -143,6 +225,8 @@
 		public Inventory Inventory { get; set; } = null;
 		public ItemIcon ItemIcon { get; set; } = null;
 		public EquipmentIcon EquipmentIcon { get; set; } = null;
+		public IRpcAction<Action<NetworkWriter>> SendDropItemToServer { get; set; }
+		public IRpcAction<GameObject> SendDropEquipmentToServer { get; set; }
 
 		private void Awake()
 		{
@@ -166,8 +250,7 @@
 
 		public void OnPointerClick(PointerEventData eventData)
 		{
-			// TODO(kookehs): Add multiplayer support.
-			if (!NetworkServer.active || ShouldDestroy) return;
+			if (ShouldDestroy) return;
 
 			CharacterBody characterBody = Inventory.GetComponent<CharacterMaster>().GetBody();
 			if (characterBody == null || characterBody.healthComponent == null || characterBody.healthComponent.alive == false) return;
@@ -178,6 +261,7 @@
 				return;
 			}
 
+			// TODO: Send notification to the player that got his item dropped.
 			Notification notification = characterBody.gameObject.AddComponent<Notification>();
 			notification.transform.SetParent(characterBody.transform);
 			notification.SetPosition(new Vector3((float)(Screen.width * 0.8), (float)(Screen.height * 0.25), 0));
@@ -193,8 +277,9 @@
 					notification.SetIcon(Resources.Load<Texture>(equipmentDef.pickupIconPath));
 					notification.GetTitle = () => "Equipment dropped";
 					notification.GetDescription = () => $"{Language.GetString(equipmentDef.nameToken)}";
-					Inventory.SetEquipmentIndex(EquipmentIndex.None);
-					PickupDropletController.CreatePickupDroplet(new PickupIndex(equipmentIndex), transform.position, Vector3.up * 20f + transform.forward * 10f);
+					SendDropEquipmentToServer.Invoke(characterBody.masterObject);
+
+					// TODO: Only send ShouldDestroy on server ACK. Maybe use an RPCFunc?
 					ShouldDestroy = true;
 					return;
 				}
@@ -209,10 +294,15 @@
 				notification.SetIcon(Resources.Load<Texture>(itemDef.pickupIconPath));
 				notification.GetTitle = () => "Item dropped";
 				notification.GetDescription = () => $"{Language.GetString(itemDef.nameToken)}";
-				Inventory.RemoveItem(itemIndex, 1);
-				PickupDropletController.CreatePickupDroplet(new PickupIndex(itemIndex), transform.position, Vector3.up * 20f + transform.forward * 10f);
+
+				print("Sending DropItem request");
+				SendDropItemToServer.Invoke(x => {
+					x.Write(characterBody.masterObject);
+					x.Write(itemIndex);
+				});
 			}
 
+			// TODO: Only send ShouldDestroy on server ACK. Maybe use an RPCFunc?
 			if (itemStacks[(int)itemIndex] <= 0)
 			{
 				ShouldDestroy = true;

--- a/DropItems/DropItems.csproj
+++ b/DropItems/DropItems.csproj
@@ -40,6 +40,9 @@
     <Reference Include="BepInEx">
       <HintPath>E:\SteamLibrary\steamapps\common\Risk of Rain 2\BepInEx\core\BepInEx.dll</HintPath>
     </Reference>
+    <Reference Include="MiniRpcLib">
+      <HintPath>..\..\wildbook-mods\MiniRpcLib\bin\Debug\netstandard2.0\MiniRpcLib.dll</HintPath>
+    </Reference>
     <Reference Include="netstandard">
       <HintPath>E:\SteamLibrary\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\netstandard.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Allows the clients to drop items too. This PR is WIP, there are a number of TODOs that I'm planning on fixing soon:

1. Let the server drive the notification, sending it to the drop requester and the user who got their item dropped.
2. Only set ShouldDestroy if the drop succeeded. Kinda complicated to do. I'm not sure what ShouldDestroy does exactly?

This adds a dependency on MiniRpcLib, which is an unreleased plugin by Wildbook. You can find it [here](https://github.com/wildbook/R2Mods/tree/develop).

For this to work, obviously, both the client and the server need to have the plugin installed.